### PR TITLE
Rearrange to group interactions in smaller timeframe

### DIFF
--- a/myupdate
+++ b/myupdate
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo zypper refresh && sudo zypper dup && sudo flatpak update
+sudo flatpak update && sudo zypper refresh && sudo zypper dup -l 
 
 while true; do
     read -p "Do you want to clean the GPU cache? (y/n): " answer


### PR DESCRIPTION
Rearranged to put flatpak before zypper as the flatpak updates usually take less time than zypper, meaning there is a smaller gap between when you need to approve updates or resolve any conflicts. Also added the -l option to dup to automatically agree with any licenses (such as Nvidia drivers)